### PR TITLE
<Feat> News Detail Page 상세 설계 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import NotFoundPage from './pages/NotFoundPage';
 import MainPage from './pages/MainPage';
 import LoginPage from './pages/LoginPage';
 import MealPage from './pages/meal/MealPage';
+import NewsPage from './pages/news/NewsPage';
 
 // 전역 스타일
 const globalStyle = css`
@@ -33,7 +34,6 @@ const globalStyle = css`
 `;
 
 const App = () => {
-  
   return (
     <>
       <AuthProvider>
@@ -50,6 +50,7 @@ const App = () => {
 
             {/* 식단 상세조회 페이지 */}
             <Route path="/meal" element={<MealPage />} />
+            <Route path="/news" element={<NewsPage />}></Route>
           </Route>
           {/* Layout 미적용 페이지 */}
           <Route path="/" element={<StartPage />}></Route>

--- a/src/api/mealApi.jsx
+++ b/src/api/mealApi.jsx
@@ -5,6 +5,7 @@ export const getWeeklyMenu = async () => {
     const response = await apiClient.get('/weeklymenus');
     return response.data.data;
   } catch (error) {
+    throw error;
     console.log('식단 메뉴 fetching 중 에러발생', error);
   }
 };

--- a/src/api/mealApi.jsx
+++ b/src/api/mealApi.jsx
@@ -5,7 +5,8 @@ export const getWeeklyMenu = async () => {
     const response = await apiClient.get('/weeklymenus');
     return response.data.data;
   } catch (error) {
+    console.log('식단 메뉴 fetching 중 에러발생, 실제 컴포넌트로 전달', error);
     throw error;
-    console.log('식단 메뉴 fetching 중 에러발생', error);
+    
   }
 };

--- a/src/api/newsApi.jsx
+++ b/src/api/newsApi.jsx
@@ -1,0 +1,11 @@
+import apiClient from './apiClient';
+
+export const getNews = async (category) => {
+  try {
+    const response = await apiClient.get('/news', { params: { category } });
+    return response.data;
+  } catch (error) {
+    console.log('뉴스 fetching 중 에러발생, 실제 컴포넌트로 전달', error);
+    throw error;
+  }
+};

--- a/src/components/MyoungjiNews.jsx
+++ b/src/components/MyoungjiNews.jsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoadingComponent from './util/LoadingComponent';
 import { getNews } from '../api/newsApi';
-import apiClient from '../api/apiClient';
 
 const newsContainerStyle = css`
   display: flex;

--- a/src/components/MyoungjiNews.jsx
+++ b/src/components/MyoungjiNews.jsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoadingComponent from './util/LoadingComponent';
+import { getNews } from '../api/newsApi';
 import apiClient from '../api/apiClient';
 
 const newsContainerStyle = css`
@@ -111,21 +112,21 @@ const loadMoreButtonStyle = css`
 const MyongjiNews = () => {
   const [newsData, setNewsData] = useState({ REPORT: [], SOCIETY: [] });
   const [loading, setLoading] = useState(true);
-
   const [activeTab, setActiveTab] = useState('REPORT');
+
   const navigate = useNavigate();
 
   useEffect(() => {
     const fetchNewsInfo = async (category) => {
       try {
         //EndPoint -> /news?category={}
-        const response = await apiClient.get('/news', { params: { category } });
-        console.log('뉴스 컴포넌트 Fetching', response.data.data.content);
+
+        const response = await getNews(category);
+        console.log('뉴스 컴포넌트 Fetching', response.data.content);
         setNewsData((prevData) => ({
           ...prevData,
-          //아래 보면 Fetching을 두번 하므로, 새로운 카테고리 속성을 추가해줘야함
-          //[category]는 동적 key임 , 배열이 아님 헷갈리지 말 것 (포스팅)
-          [category]: response.data.data.content,
+
+          [category]: response.data.content,
         }));
       } catch (error) {
         console.log('명대신문 데이터 서버 오류', error);

--- a/src/pages/news/NewsPage.jsx
+++ b/src/pages/news/NewsPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NewsPage = () => {
+  return <div>np</div>;
+};
+
+export default NewsPage;

--- a/src/pages/news/NewsPage.jsx
+++ b/src/pages/news/NewsPage.jsx
@@ -1,7 +1,169 @@
-import React from 'react';
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+import { getNews } from '../../api/newsApi';
+import LoadingComponent from '../../components/util/LoadingComponent';
+
+const newsDetailContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+  width: 100%;
+  max-width: 1200px;
+`;
+const tabsContainerStyle = css`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  border-bottom: 2px solid #ddd;
+  align-items: flex-start;
+`;
+
+const tabStyle = (isActive) => css`
+  display: flex;
+  flex-direction: row;
+  text-align: center;
+  color: gray;
+  padding: 20px;
+  cursor: pointer;
+  border-bottom: ${isActive ? '3px solid navy' : '3px solid transparent'};
+  &:hover {
+    background-color: #eef1ff;
+  }
+`;
+const newsImageStyle = css`
+  width: 200px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 6px;
+  margin-right: 20px;
+`;
+const newsCardStyle = css`
+  display: flex;
+  flex-direction: row;
+  background: white;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    transform: scale(1.02);
+  }
+`;
+const newsContentStyle = css`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+const newsTitleStyle = css`
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #001f5c;
+  margin-bottom: 5px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const newsSummaryStyle = css`
+  font-size: 1rem;
+  color: #333;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const newsLinkStyle = css`
+  text-decoration: none;
+`;
 
 const NewsPage = () => {
-  return <div>np</div>;
+  const [newsData, setNewsData] = useState({ REPORT: [], SOCIETY: [] });
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState('REPORT');
+
+  useEffect(() => {
+    const fetchNews = async (category) => {
+      try {
+        const response = await getNews(category);
+        setNewsData((prev) => ({
+          ...prev,
+          [category]: response.data.content,
+        }));
+        setLoading(false);
+      } catch (error) {
+        console.log('news 상세 페이지 fetching 실패');
+      }
+    };
+    fetchNews('REPORT');
+    fetchNews('SOCIETY');
+  }, []);
+
+  const activeNews = newsData[activeTab] || [];
+  const slicedNews = activeNews.slice(0, 9);
+
+  if (loading) {
+    return <LoadingComponent message="명대신문 다운 받는중입니다." />;
+  }
+
+  return (
+    <div css={newsDetailContainerStyle}>
+      <h1 style={{ color: 'navy' }}>명대신문</h1>
+      <div css={tabsContainerStyle}>
+        <div
+          css={tabStyle(activeTab === 'REPORT')}
+          onClick={() => setActiveTab('REPORT')}
+        >
+          보도자료
+        </div>
+        <div
+          css={tabStyle(activeTab === 'SOCIETY')}
+          onClick={() => setActiveTab('SOCIETY')}
+        >
+          사회자료
+        </div>
+      </div>
+
+      {slicedNews.length > 0 ? (
+        slicedNews.map((news, idx) => (
+          <div key={idx} css={newsCardStyle}>
+            <img
+              css={newsImageStyle}
+              src={news.imageUrl || '/default-placeholder.png'}
+              alt="뉴스 이미지 없음"
+            />
+            <div css={newsContentStyle}>
+              <h2 css={newsTitleStyle}>
+                <a
+                  css={newsLinkStyle}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href={news.link}
+                >
+                  {news.title}
+                </a>
+              </h2>
+              <p css={newsSummaryStyle}>{news.summary}</p>
+            </div>
+          </div>
+        ))
+      ) : (
+        <p>표시할 뉴스가 존재하지 않습니다.</p>
+      )}
+    </div>
+  );
 };
 
 export default NewsPage;


### PR DESCRIPTION
#17 
17번 이슈, news 상세 페이지 작성했습니다.

메인페이지 내 뉴스랑 사실 로직은 유사합니다.

디자인이 없어서 그냥 기존 뉴스 컴포넌트 디자인을 통일시켰습니다
<img width="1920" alt="스크린샷 2025-03-18 오후 8 19 07" src="https://github.com/user-attachments/assets/6ed4714f-d0a1-459a-be48-745dc05edc0c" />
