### PR TITLE
<Fix> 회원가입 시 이메일 검증 로직 변경

### DIFF
--- a/src/hooks/useSignupForm.js
+++ b/src/hooks/useSignupForm.js
@@ -1,0 +1,171 @@
+// ### useSignUpForm 훅의 역할
+
+// - 회원가입 폼 전체 로직을 상태 기반으로 관리하는 컨트롤러 훅
+// - 입력값 상태, 단계 전환, 유효성 검사, 조건부 렌더링, 제출 처리까지 전반적인 흐름을 담당함
+// - 컴포넌트(SignUpPage)는 이 훅에서 제공하는 값만 사용해 UI를 렌더링하도록 설계됨
+import { useEffect, useState } from 'react';
+import { verifyMjuEmail, verifyPassword } from '@/util/verifyRegex';
+import { useAuth } from '@/context/AuthContext';
+
+const useSignupForm = () => {
+  const [step, setStep] = useState(1);
+  const [isSignUpComplete, setIsSignUpcomplete] = useState(false);
+  const { signup } = useAuth();
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+  const [isMjuEmail, setIsMjuMail] = useState(false);
+  const [MjuEmailError, setMjuEmailError] = useState('');
+
+  //입력상태 통일 (여러개의 useState로 setState 처리하는것 보다 이게 훨씬 효율적)
+  //또한 서버에 전송할때 이렇게 묶는게 훨씬 효율적
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    department: '',
+    studentId: '',
+    gender: '',
+    nickname: '',
+  });
+
+  const {
+    name,
+    email,
+    password,
+    confirmPassword,
+    department,
+    studentId,
+    gender,
+    nickname,
+  } = formData;
+
+  const handleChange = (stateAttribute) => (e) => {
+    setFormData((prev) => ({ ...prev, [stateAttribute]: e.target.value }));
+  };
+
+  //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
+  useEffect(() => {
+    if (!verifyPassword(password))
+      setPasswordError(
+        '비밀번호는 영문, 숫자, 특수문자 포함 8-16자여야 합니다.'
+      );
+    else {
+      setPasswordError('');
+    }
+  }, [password]);
+
+  // 상태 변경을 위한 useEffect
+  const [showEmail, setShowEmail] = useState(false);
+  const [showPasswordField, setShowPasswordField] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [showStudentId, setShowStudentId] = useState(false);
+  const [showGender, setShowGender] = useState(false);
+  const [showNickname, setShowNickname] = useState(false);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!verifyMjuEmail(email)) {
+      setShowPasswordField(false);
+      setIsMjuMail(false);
+      setMjuEmailError(
+        '이메일 형식은 명지대학교의 공식 학생 이메일이어야만 합니다.'
+      );
+    }
+    if (verifyMjuEmail(email)) {
+      setShowPasswordField(true);
+      setMjuEmailError('');
+    }
+  }, [email]);
+
+  useEffect(() => {
+    if (name.length >= 2) setShowEmail(true);
+  }, [name]);
+
+  useEffect(() => {
+    if (password.length >= 8) setShowConfirmPassword(true);
+    else setShowConfirmPassword(false);
+  }, [password]);
+
+  useEffect(() => {
+    if (department.length > 2) setShowStudentId(true);
+    else setShowStudentId(false);
+  }, [department]);
+
+  useEffect(() => {
+    if (studentId.length >= 6) setShowGender(true);
+    else setShowGender(false);
+  }, [studentId]);
+
+  useEffect(() => {
+    if (gender) setShowNickname(true);
+    else setShowNickname(false);
+  }, [gender]);
+
+  //요청한 스텝바이스텝을 위한 상태값 (1 상태)
+  const isStepOneValid =
+    //첫번째 네개의 값이 다 채워지면 1상태
+    name && email && password && confirmPassword && isMjuEmail;
+  password === confirmPassword;
+
+  //(2상태) 두번째 네개의 값이 다 채워지면 2상태
+  const isStepTwoValid = department && studentId && gender && nickname;
+
+  const handleNextStep = () => {
+    if (step === 1 && isStepOneValid) {
+      setStep(2);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    //서버에 보낼 객체값가공
+    const newUser = {
+      name,
+      email,
+      password,
+      department,
+      studentId,
+      gender,
+      nickname,
+    };
+
+    try {
+      await signup(newUser);
+      setIsSignUpcomplete(true);
+      //회원가입 성공하면 로그인 페이지로 리다리엑션
+      setTimeout(() => {
+        navigate('/login');
+      }, 500);
+    } catch (e) {
+      alert('회원가입에 실패했습니다.');
+      console.log('회원가입 실패', e);
+    }
+  };
+
+  return {
+    step,
+    isSignUpComplete,
+    formData,
+    handleChange,
+    handleNextStep,
+    handleSubmit,
+    isStepOneValid,
+    isStepTwoValid,
+    showPassword,
+    setShowPassword,
+    passwordError,
+    MjuEmailError,
+    showEmail,
+    showPasswordField,
+    showConfirmPassword,
+    showStudentId,
+    showGender,
+    showNickname,
+  };
+};
+
+export default useSignupForm;

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   const handlePasswordChange = (e) => setPassword(e.target.value);
 
   //authContext에서 구현한 로그인 함수들을 가져옴
-  const { postLogin, setIsLoggedIn } = useAuth();
+  const { login, setIsLoggedIn } = useAuth();
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
@@ -36,7 +36,7 @@ const LoginPage = () => {
       console.log('📤 로그인 요청 데이터:', userInfo); // 🚀 콘솔에서 확인
       //postLOGIn으로
 
-      await postLogin(userInfo);
+      await login(userInfo);
       setIsLoggedIn(true);
       setIsSuccessMessageModalOpen(true);
     } catch (e) {

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -12,7 +12,8 @@ const LoginPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const [isSuccessMessageModalOpen, setIsSuccessMessageModalOpen] = useState(false);
+  const [isSuccessMessageModalOpen, setIsSuccessMessageModalOpen] =
+    useState(false);
   const [isSignUpModalOpen, setIsSignUpModalOpen] = useState(false);
 
   const openSignUpModal = () => setIsSignUpModalOpen(true);
@@ -23,7 +24,7 @@ const LoginPage = () => {
   const handlePasswordChange = (e) => setPassword(e.target.value);
 
   //authContext에서 구현한 로그인 함수들을 가져옴
-  const { login, setIsLoggedIn } = useAuth();
+  const { postLogin, setIsLoggedIn } = useAuth();
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
@@ -33,8 +34,9 @@ const LoginPage = () => {
       };
 
       console.log('📤 로그인 요청 데이터:', userInfo); // 🚀 콘솔에서 확인
+      //postLOGIn으로
 
-      await login(userInfo);
+      await postLogin(userInfo);
       setIsLoggedIn(true);
       setIsSuccessMessageModalOpen(true);
     } catch (e) {

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -6,6 +6,7 @@ import { FaEye, FaEyeSlash, FaCheck } from 'react-icons/fa'; // 눈 아이콘 �
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../context/AuthContext';
+import { postSignup } from '@/api/authApi';
 
 const modalOverlayStyle = css`
   position: fixed;
@@ -72,7 +73,7 @@ const buttonStyle = (enabled) => css`
   cursor: ${enabled ? 'pointer' : 'not-allowed'};
 `;
 
-const passwordErrorStyle = css`
+const ErrorStyle = css`
   color: red;
   font-size: 12px;
   text-align: left;
@@ -81,7 +82,7 @@ const passwordErrorStyle = css`
   margin-bottom: 10px;
 `;
 
-const passwordConfirmStyle = css`
+const ConfirmStyle = css`
   color: #28a745; /* 연두색 */
   font-size: 12px;
   text-align: left;
@@ -119,6 +120,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const PASSWORD_REGEX =
     /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/;
 
+  const MJU_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@mju\.ac\.kr$/;
   //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
   useEffect(() => {
     if (password.length > 0 && !PASSWORD_REGEX.test(password)) {
@@ -136,7 +138,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const [showStudentId, setShowStudentId] = useState(false);
   const [showGender, setShowGender] = useState(false);
   const [showNickname, setShowNickname] = useState(false);
-
+  const [isMjuEmail, setIsMjuMail] = useState(false);
   const navigate = useNavigate();
 
   //영은 요청 다음거 보여주는 useEffect.. 상태변경보단 이게 나음. showX 를 의존해서 바꿈
@@ -193,7 +195,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
     };
 
     try {
-      const data = await signup(newUser);
+      const data = await postSignup(newUser);
 
       setIsSignUpcomplete(true);
       //회원가입 성공하면 로그인 페이지로 리다리엑션
@@ -241,7 +243,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
                   )}
                   {/* 비밀번호의 형식을 갖추지 않고 쓸 경우의 오류 */}
                   {passwordError && password.length > 1 ? (
-                    <span css={passwordErrorStyle}>{passwordError}</span>
+                    <span css={ErrorStyle}>{passwordError}</span>
                   ) : null}
                   {showPasswordField && (
                     <div css={inputContainerStyle}>
@@ -273,11 +275,9 @@ const SignUpPage = ({ closeSignUpModal }) => {
 
                   {/* 확인 비밀번호를 틀릴경우  */}
                   {confirmPassword && confirmPassword !== password ? (
-                    <p css={passwordErrorStyle}>
-                      비밀번호가 일치하지 않습니다.
-                    </p>
+                    <p css={ErrorStyle}>비밀번호가 일치하지 않습니다.</p>
                   ) : confirmPassword && confirmPassword === password ? (
-                    <p css={passwordConfirmStyle}>확인되었습니다!</p>
+                    <p css={ConfirmStyle}>확인되었습니다!</p>
                   ) : null}
                   <button
                     type="button"

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-
+import useSignupForm from '@/hooks/useSignupForm';
 import { useEffect, useState } from 'react';
 import { FaEye, FaEyeSlash, FaCheck } from 'react-icons/fa'; // 눈 아이콘 추가
 import { useNavigate } from 'react-router-dom';
@@ -98,125 +98,47 @@ const successIconStyle = css`
 `;
 
 const SignUpPage = ({ closeSignUpModal }) => {
-  const [step, setStep] = useState(1);
-  const [isSignUpComplete, setIsSignUpcomplete] = useState(false);
-  const { signup } = useAuth();
-
-  // 입력 상태
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-
-  const [department, setDepartment] = useState('');
-  const [studentId, setStudentId] = useState('');
-  const [gender, setGender] = useState('');
-  const [nickname, setNickname] = useState('');
-
-  const [showPassword, setShowPassword] = useState(false);
-  const [passwordError, setPasswordError] = useState('');
-  const [isMjuEmail, setIsMjuMail] = useState(false);
-  const [MjuEmailError, setMjuEmailError] = useState('');
-
-  //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
-  useEffect(() => {
-    if (!verifyPassword(password))
-      setPasswordError(
-        '비밀번호는 영문, 숫자, 특수문자 포함 8-16자여야 합니다.'
-      );
-    else {
-      setPasswordError('');
-    }
-  }, [password]);
-  // 상태 변경을 위한 useEffect
-  const [showEmail, setShowEmail] = useState(false);
-  const [showPasswordField, setShowPasswordField] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [showStudentId, setShowStudentId] = useState(false);
-  const [showGender, setShowGender] = useState(false);
-  const [showNickname, setShowNickname] = useState(false);
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (name.length >= 2) setShowEmail(true);
-  }, [name]);
-
-  useEffect(() => {
-    if (!verifyMjuEmail(email) && email.length > 1) {
-      setShowPasswordField(false);
-      setIsMjuMail(false);
-      setMjuEmailError(
-        '이메일 형식은 명지대학교의 공식 학생 이메일이어야만 합니다.'
-      );
-    }
-    if (verifyMjuEmail(email)) {
-      setShowPasswordField(true);
-      setMjuEmailError('');
-    }
-  }, [email]);
-
-  useEffect(() => {
-    if (password.length >= 8) setShowConfirmPassword(true);
-    else setShowConfirmPassword(false);
-  }, [password]);
-
-  useEffect(() => {
-    if (department.length > 2) setShowStudentId(true);
-    else setShowStudentId(false);
-  }, [department]);
-
-  useEffect(() => {
-    if (studentId.length >= 6) setShowGender(true);
-    else setShowGender(false);
-  }, [studentId]);
-
-  useEffect(() => {
-    if (gender) setShowNickname(true);
-    else setShowNickname(false);
-  }, [gender]);
-
-  //요청한 스텝바이스텝을 위한 상태값 (1 상태)
-  const isStepOneValid =
-    //첫번째 네개의 값이 다 채워지면 1상태
-    name && email && password && confirmPassword && isMjuEmail;
-  password === confirmPassword;
-
-  //(2상태) 두번째 네개의 값이 다 채워지면 2상태
-  const isStepTwoValid = department && studentId && gender && nickname;
-
-  const handleNextStep = () => {
-    if (step === 1 && isStepOneValid) {
-      setStep(2);
-    }
-  };
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-
-    //서버에 보낼 객체값가공
-    const newUser = {
+  //커스텀훅의 return 값을 중첩 구조분해 할당하여 return
+  const {
+    values: {
       name,
       email,
       password,
+      confirmPassword,
       department,
       studentId,
       gender,
       nickname,
-    };
-
-    try {
-      await signup(newUser);
-      setIsSignUpcomplete(true);
-      //회원가입 성공하면 로그인 페이지로 리다리엑션
-      setTimeout(() => {
-        navigate('/login');
-      }, 500);
-    } catch (e) {
-      alert('회원가입에 실패했습니다.');
-      console.log('회원가입 실패', e);
-    }
-  };
+    },
+    setters: {
+      setName,
+      setEmail,
+      setPassword,
+      setConfirmPassword,
+      setDepartment,
+      setStudentId,
+      setGender,
+      setNickname,
+    },
+    errors: { passwordError, MjuEmailError },
+    flags: {
+      isStepOneValid,
+      isStepTwoValid,
+      step,
+      isSignUpComplete,
+      isMjuEmail,
+    },
+    display: {
+      showEmail,
+      showPasswordField,
+      showConfirmPassword,
+      showStudentId,
+      showGender,
+      showNickname,
+      showPassword,
+    },
+    actions: { setShowPassword, handleNextStep, handleSubmit },
+  } = useSignupForm();
 
   return (
     <div css={modalOverlayStyle} onClick={closeSignUpModal}>

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -116,11 +116,12 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [passwordError, setPasswordError] = useState('');
 
-  //비밀번호 검증 정규식 (영문,숫자, 그리고 특수문자도 가능요)
+  //검증 정규식 (영문,숫자, 그리고 특수문자도 가능요)
   const PASSWORD_REGEX =
     /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/;
 
   const MJU_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@mju\.ac\.kr$/;
+
   //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
   useEffect(() => {
     if (password.length > 0 && !PASSWORD_REGEX.test(password)) {
@@ -139,11 +140,12 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const [showGender, setShowGender] = useState(false);
   const [showNickname, setShowNickname] = useState(false);
   const [isMjuEmail, setIsMjuMail] = useState(false);
+
   const navigate = useNavigate();
 
   //영은 요청 다음거 보여주는 useEffect.. 상태변경보단 이게 나음. showX 를 의존해서 바꿈
   useEffect(() => {
-    if (name.length > 2) setShowEmail(true);
+    if (name.length >= 2) setShowEmail(true);
   }, [name]);
 
   useEffect(() => {
@@ -169,11 +171,19 @@ const SignUpPage = ({ closeSignUpModal }) => {
   //요청한 스텝바이스텝을 위한 상태값 (1 상태)
   const isStepOneValid =
     //첫번째 네개의 값이 다 채워지면 1상태
-    name && email && password && confirmPassword === password;
+    name && email && password && confirmPassword && isMjuEmail === password;
 
   //(2상태) 두번째 네개의 값이 다 채워지면 2상태
   const isStepTwoValid = department && studentId && gender && nickname;
 
+  //이메일 입력하고 난 뒤
+  const handleEmailChange = (email) => {
+    const rightInput = MJU_EMAIL_REGEX.test(email);
+
+    if (rightInput) {
+      setIsMjuMail(true);
+    }
+  };
   const handleNextStep = () => {
     if (step === 1 && isStepOneValid) {
       setStep(2);
@@ -195,8 +205,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
     };
 
     try {
-      const data = await postSignup(newUser);
-
+      await signup(newUser);
       setIsSignUpcomplete(true);
       //회원가입 성공하면 로그인 페이지로 리다리엑션
       setTimeout(() => {

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -120,7 +120,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
 
   //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
   useEffect(() => {
-    if (verifyPassword(password))
+    if (!verifyPassword(password))
       setPasswordError(
         '비밀번호는 영문, 숫자, 특수문자 포함 8-16자여야 합니다.'
       );
@@ -138,21 +138,21 @@ const SignUpPage = ({ closeSignUpModal }) => {
 
   const navigate = useNavigate();
 
-  //영은 요청 다음거 보여주는 useEffect.. 상태변경보단 이게 나음. showX 를 의존해서 바꿈
   useEffect(() => {
     if (name.length >= 2) setShowEmail(true);
   }, [name]);
 
-  //이메일이 바뀔때 -> effect check MJU EMAIL REGEX
   useEffect(() => {
-    if (verifyMjuEmail(email)) {
+    if (!verifyMjuEmail(email)) {
       setShowPasswordField(false);
       setIsMjuMail(false);
       setMjuEmailError(
         '이메일 형식은 명지대학교의 공식 이메일이어야만 합니다.'
       );
-    } else {
-      setShowPasswordField();
+    }
+    if (verifyMjuEmail(email)) {
+      setShowPasswordField(true);
+      setMjuEmailError('');
     }
   }, [email]);
 

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -143,7 +143,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
   }, [name]);
 
   useEffect(() => {
-    if (!verifyMjuEmail(email)) {
+    if (!verifyMjuEmail(email) && email.length > 1) {
       setShowPasswordField(false);
       setIsMjuMail(false);
       setMjuEmailError(

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -6,7 +6,7 @@ import { FaEye, FaEyeSlash, FaCheck } from 'react-icons/fa'; // 눈 아이콘 �
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../context/AuthContext';
-import { postSignup } from '@/api/authApi';
+import { verifyMjuEmail, verifyPassword } from '@/util/verifyRegex';
 
 const modalOverlayStyle = css`
   position: fixed;
@@ -117,19 +117,14 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const [passwordError, setPasswordError] = useState('');
   const [isMjuEmail, setIsMjuMail] = useState(false);
   const [MjuEmailError, setMjuEmailError] = useState('');
-  //검증 정규식 (영문,숫자, 그리고 특수문자도 가능요)
-  const PASSWORD_REGEX =
-    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/;
-
-  const MJU_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@mju\.ac\.kr$/;
 
   //비밀번호가 입력칸이 바뀔때 -> effect passWord 상태를 최신화 (의존성 배열에 password추가)
   useEffect(() => {
-    if (password.length > 0 && !PASSWORD_REGEX.test(password)) {
+    if (verifyPassword(password))
       setPasswordError(
         '비밀번호는 영문, 숫자, 특수문자 포함 8-16자여야 합니다.'
       );
-    } else {
+    else {
       setPasswordError('');
     }
   }, [password]);
@@ -150,14 +145,14 @@ const SignUpPage = ({ closeSignUpModal }) => {
 
   //이메일이 바뀔때 -> effect check MJU EMAIL REGEX
   useEffect(() => {
-    if (email.length > 0 && !MJU_EMAIL_REGEX.test(email)) {
+    if (verifyMjuEmail(email)) {
       setShowPasswordField(false);
       setIsMjuMail(false);
       setMjuEmailError(
         '이메일 형식은 명지대학교의 공식 이메일이어야만 합니다.'
       );
     } else {
-      setShowPasswordField(true);
+      setShowPasswordField();
     }
   }, [email]);
 

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -115,7 +115,8 @@ const SignUpPage = ({ closeSignUpModal }) => {
 
   const [showPassword, setShowPassword] = useState(false);
   const [passwordError, setPasswordError] = useState('');
-
+  const [isMjuEmail, setIsMjuMail] = useState(false);
+  const [MjuEmailError, setMjuEmailError] = useState('');
   //검증 정규식 (영문,숫자, 그리고 특수문자도 가능요)
   const PASSWORD_REGEX =
     /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/;
@@ -139,7 +140,6 @@ const SignUpPage = ({ closeSignUpModal }) => {
   const [showStudentId, setShowStudentId] = useState(false);
   const [showGender, setShowGender] = useState(false);
   const [showNickname, setShowNickname] = useState(false);
-  const [isMjuEmail, setIsMjuMail] = useState(false);
 
   const navigate = useNavigate();
 
@@ -148,42 +148,48 @@ const SignUpPage = ({ closeSignUpModal }) => {
     if (name.length >= 2) setShowEmail(true);
   }, [name]);
 
+  //이메일이 바뀔때 -> effect check MJU EMAIL REGEX
   useEffect(() => {
-    if (email.includes('@')) setShowPasswordField(true);
+    if (email.length > 0 && !MJU_EMAIL_REGEX.test(email)) {
+      setShowPasswordField(false);
+      setIsMjuMail(false);
+      setMjuEmailError(
+        '이메일 형식은 명지대학교의 공식 이메일이어야만 합니다.'
+      );
+    } else {
+      setShowPasswordField(true);
+    }
   }, [email]);
 
   useEffect(() => {
     if (password.length >= 8) setShowConfirmPassword(true);
+    else setShowConfirmPassword(false);
   }, [password]);
 
   useEffect(() => {
     if (department.length > 2) setShowStudentId(true);
+    else setShowStudentId(false);
   }, [department]);
 
   useEffect(() => {
     if (studentId.length >= 6) setShowGender(true);
+    else setShowGender(false);
   }, [studentId]);
 
   useEffect(() => {
     if (gender) setShowNickname(true);
+    else setShowNickname(false);
   }, [gender]);
 
   //요청한 스텝바이스텝을 위한 상태값 (1 상태)
   const isStepOneValid =
     //첫번째 네개의 값이 다 채워지면 1상태
-    name && email && password && confirmPassword && isMjuEmail === password;
+    name && email && password && confirmPassword && isMjuEmail;
+  password === confirmPassword;
 
   //(2상태) 두번째 네개의 값이 다 채워지면 2상태
   const isStepTwoValid = department && studentId && gender && nickname;
 
-  //이메일 입력하고 난 뒤
-  const handleEmailChange = (email) => {
-    const rightInput = MJU_EMAIL_REGEX.test(email);
-
-    if (rightInput) {
-      setIsMjuMail(true);
-    }
-  };
   const handleNextStep = () => {
     if (step === 1 && isStepOneValid) {
       setStep(2);
@@ -241,6 +247,10 @@ const SignUpPage = ({ closeSignUpModal }) => {
                     onChange={(e) => setName(e.target.value)}
                     css={inputStyle}
                   />
+                  {/* 명지대 이메일로 쓰지 않았을 경우.. 오류 발생 */}
+                  {!isMjuEmail && password.length > 1 ? (
+                    <span css={ErrorStyle}> {MjuEmailError}</span>
+                  ) : null}
                   {showEmail && (
                     <input
                       type="email"

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -147,7 +147,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
       setShowPasswordField(false);
       setIsMjuMail(false);
       setMjuEmailError(
-        '이메일 형식은 명지대학교의 공식 이메일이어야만 합니다.'
+        '이메일 형식은 명지대학교의 공식 학생 이메일이어야만 합니다.'
       );
     }
     if (verifyMjuEmail(email)) {
@@ -213,7 +213,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
         navigate('/login');
       }, 500);
     } catch (e) {
-      alert('회원가입에 실패했습니다');
+      alert('회원가입에 실패했습니다.');
       console.log('회원가입 실패', e);
     }
   };
@@ -242,8 +242,7 @@ const SignUpPage = ({ closeSignUpModal }) => {
                     onChange={(e) => setName(e.target.value)}
                     css={inputStyle}
                   />
-                  {/* 명지대 이메일로 쓰지 않았을 경우.. 오류 발생 */}
-                  {!isMjuEmail && password.length > 1 ? (
+                  {!isMjuEmail ? (
                     <span css={ErrorStyle}> {MjuEmailError}</span>
                   ) : null}
                   {showEmail && (

--- a/src/util/verifyRegex.js
+++ b/src/util/verifyRegex.js
@@ -1,0 +1,13 @@
+//검증 정규식 (영문,숫자, 그리고 특수문자도 가능요)
+const PASSWORD_REGEX =
+  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/;
+
+const MJU_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@mju\.ac\.kr$/;
+
+export const verifyPassword = (password) => {
+  return password.length > 0 && PASSWORD_REGEX.test(password);
+};
+
+export const verifyMjuEmail = (email) => {
+  return email.length > 0 && MJU_EMAIL_REGEX.test(email);
+};


### PR DESCRIPTION
#26 

원래는 모든 이메일을 허용했는데, 프론트 측에서 mju.ac.kr의 형식으로 하게끔
바꿔놨습니다.
<img width="496" alt="스크린샷 2025-03-27 오후 12 40 46" src="https://github.com/user-attachments/assets/33e40b97-db35-4477-aa13-fad6b8829b0c" />


백엔드에서 아마 형식말고도 실제 존재하는 이메일인지 검증 기능은 필요 할듯 합니다.
또한, signupPage에 사실 코드 양이 많아 필요하면 좀 분리를 하면 좋을 듯 합니다.